### PR TITLE
feat: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+##end_of_line = lf
+charset = utf-8
+##trim_trailing_whitespace = true
+##insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[{CMakeLists.*,*.cmake}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.{bat,cmd,cmd.*}]
+end_of_line = crlf
+indent_style = space
+indent_size = 2
+
+[*.{ps1,ps1.*}]
+end_of_line = crlf
+indent_style = space
+indent_size = 4
+
+[*.{md,markdown}]
+indent_size = 4


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org/) 提供了针对当前工程统一配置的缩进(space vs tab)、换行(\n vs \r)、编码（UTF-8 vs ANSI） 等配置。

常见编辑器/IDE(VSCode，Visual Studio、CLion）都有提供相应的插件。

协作时大家装好插件后，在项目中新增的文件， 通常可以确保统一的缩进、换行、编码风格。

P.S. 此 .editorconfig 是基于 [OpenCV 官方的 .editorconfig](https://github.com/opencv/opencv/blob/master/.editorconfig) 修改而来。