### PR TITLE
feat: Mat ctor support initializer list

### DIFF
--- a/shufaCV/Mat.cpp
+++ b/shufaCV/Mat.cpp
@@ -2,11 +2,21 @@
 
 namespace sfcv
 {
-Mat::Mat(const std::vector<int>& dim)
+Mat::Mat(const std::vector<int>& dim):
+    data_size_(1), dim_(dim)
 {
-    dim_ = dim;
-    data_size_ = 1;
-    for (auto d : dim_)
+    create();
+}
+
+Mat::Mat(std::initializer_list<int> dim):
+    data_size_(1), dim_(dim)
+{
+    create();
+}
+
+void Mat::create()
+{
+    for(auto d : dim_)
     {
         data_size_ *= d;
     }
@@ -17,5 +27,6 @@ Mat::Mat(const std::vector<int>& dim)
         data_ = shared_data_->data();
     }
 }
+
 }
 

--- a/shufaCV/Mat.cpp
+++ b/shufaCV/Mat.cpp
@@ -8,7 +8,7 @@ Mat::Mat(const std::vector<int>& dim):
     create();
 }
 
-Mat::Mat(std::initializer_list<int> dim):
+Mat::Mat(const std::initializer_list<int> dim):
     data_size_(1), dim_(dim)
 {
     create();
@@ -16,7 +16,7 @@ Mat::Mat(std::initializer_list<int> dim):
 
 void Mat::create()
 {
-    for(auto d : dim_)
+    for(const auto d : dim_)
     {
         data_size_ *= d;
     }

--- a/shufaCV/Mat.h
+++ b/shufaCV/Mat.h
@@ -23,7 +23,7 @@ protected:
 
 public:
     Mat(const std::vector<int>& dim);
-    Mat(std::initializer_list<int> dim);
+    Mat(const std::initializer_list<int> dim);
     Mat(int m, int n) : Mat(std::vector<int>{ m, n }) {}
     Mat() {}
 

--- a/shufaCV/Mat.h
+++ b/shufaCV/Mat.h
@@ -19,8 +19,11 @@ protected:
 
     void* user_data_ = nullptr;
 
+    void create(); // ctors reuse this
+
 public:
     Mat(const std::vector<int>& dim);
+    Mat(std::initializer_list<int> dim);
     Mat(int m, int n) : Mat(std::vector<int>{ m, n }) {}
     Mat() {}
 

--- a/tests/test_mat.cpp
+++ b/tests/test_mat.cpp
@@ -6,15 +6,23 @@ TEST(Mat, create)
     constexpr int rows = 3;
     constexpr int cols = 5;
 
+    // Mat::Mat(int, int)
     sfcv::Mat mat(rows, cols);
     EXPECT_TRUE(mat.data() != nullptr);
     EXPECT_EQ(mat.row(), rows);
     EXPECT_EQ(mat.col(), cols);
 
+    // Mat::Mat(const std::vector<int>&)
     sfcv::Mat mat2(std::vector<int>{rows, cols});
-    EXPECT_TRUE(mat.data() != nullptr);
+    EXPECT_TRUE(mat2.data() != nullptr);
     EXPECT_EQ(mat2.row(), rows);
     EXPECT_EQ(mat2.col(), cols);
+
+    // Mat::Mat(std::initializer_list<int>)
+    sfcv::Mat mat3({rows, cols});
+    EXPECT_TRUE(mat3.data() != nullptr);
+    EXPECT_EQ(mat3.row(), rows);
+    EXPECT_EQ(mat3.col(), cols);
 }
 
 TEST(Mat, create_const)


### PR DESCRIPTION
按 nihui 的建议增加了 dim 为 initializer_list 版本的 Mat 构造函数。

重构了原有的 dim 为 vector 的 Mat 构造函数，复用 create( ) 函数 （新增）。

增加了单元测试（啊其实看不出来调用了哪个构造函数，得自行加print才可以验证）。